### PR TITLE
Port to the pure-Rust lzma-rust2 crate to decompress LZMA1/LZMA2 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -70,7 +70,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -946,7 +946,7 @@ dependencies = [
  "flate2",
  "itertools 0.14.0",
  "jiff",
- "liblzma",
+ "lzma-rust2",
  "nt-time",
  "reqwest",
  "rstest",
@@ -1109,26 +1109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "liblzma"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
-dependencies = [
- "liblzma-sys",
-]
-
-[[package]]
-name = "liblzma-sys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1172,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 
 [[package]]
 name = "memchr"
@@ -1662,7 +1648,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1719,7 +1705,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1897,7 +1883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2429,7 +2415,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,6 @@ itertools = { version = "0.14.0", default-features = false }
 num-traits = "0.2.19"
 ratatui = { version = "0.29.0", default-features = false, features = ["crossterm"] }
 
-[features]
-lzma-static = ["inno/lzma-static"]
-
 [profile.release]
 codegen-units = 1
 lto = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,14 +18,13 @@ encoding_rs = { version = "0.8.29", default-features = false, features = ["alloc
 flate2 = { version = "1.0.13", default-features = false, features = ["zlib"] }
 itertools = { version = "0.14", default-features = false }
 jiff = { version = "0.2", default-features = false, optional = true }
-liblzma = { version = "0.4", default-features = false, features = ["bindgen"] }
+lzma-rust2 = { version = "0.16", default-features = false, features = ["std"] }
 nt-time = { version = "0.15", default-features = false, features = ["dos-date-time"] }
 thiserror = { version = "2", default-features = false }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "std"] }
 
 [features]
 chrono = ["dep:chrono", "nt-time/chrono"]
-lzma-static = ["liblzma/static"]
 jiff = ["dep:jiff", "nt-time/jiff"]
 
 [dev-dependencies]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -72,13 +72,8 @@ changes. In that case, you will get [`InnoError::UnsupportedVersion`].
 # Features
 
 - LZMA/BZip2/Deflate detection through header metadata.
-- Optional static LZMA linking via the `lzma-static` feature for consumers that
-  need it:
-
-  ```toml
-  [dependencies]
-  inno = { version = "0.2", features = ["lzma-static"] }
-  ```
+- LZMA1 decompression of the Inno header stream via the pure-Rust `lzma-rust2`
+  crate, with no C dependency or native toolchain required.
 
 # Error handling
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -136,6 +136,7 @@ use error::{HeaderStream, InnoError};
 pub use header::Header;
 use itertools::Itertools;
 use loader::SetupLoader;
+use lzma_stream_header::LzmaStreamHeader;
 use read::{ReadBytesExt, stream::InnoStreamReader};
 use version::{InnoVersion, windows_version::WindowsVersionRange};
 pub use wizard::Wizard;

--- a/core/src/lzma_stream_header.rs
+++ b/core/src/lzma_stream_header.rs
@@ -1,20 +1,24 @@
-use std::io::{Error, ErrorKind, Read, Result};
-
-use liblzma::stream::{Filters, Stream};
+use std::io::{Read, Result};
 
 pub struct LzmaStreamHeader;
 
 impl LzmaStreamHeader {
-    pub fn read<R>(src: &mut R) -> Result<Stream>
+    /// Parses the 5-byte raw LZMA1 properties header used by Inno Setup's LZMA1
+    /// streams (same layout as the `.lzma` format): a single properties byte
+    /// encoding lc/lp/pb, followed by a little-endian `u32` dictionary size.
+    pub fn read<R>(src: &mut R) -> Result<(u8, u32)>
     where
         R: Read,
     {
         let mut properties = [0; 5];
         src.read_exact(&mut properties)?;
-
-        let mut filters = Filters::new();
-        filters.lzma1_properties(&properties)?;
-
-        Stream::new_raw_decoder(&filters).map_err(|error| Error::new(ErrorKind::InvalidData, error))
+        let props = properties[0];
+        let dict_size = u32::from_le_bytes([
+            properties[1],
+            properties[2],
+            properties[3],
+            properties[4],
+        ]);
+        Ok((props, dict_size))
     }
 }

--- a/core/src/lzma_stream_header.rs
+++ b/core/src/lzma_stream_header.rs
@@ -1,24 +1,27 @@
-use std::io::{Read, Result};
+use zerocopy::{FromBytes, Immutable, KnownLayout, LE, U32};
 
-pub struct LzmaStreamHeader;
+/// The 5-byte raw LZMA1 properties header used by Inno Setup's LZMA1 streams (same layout as the
+/// `.lzma` format): a single properties byte encoding lc/lp/pb, followed by a little-endian `u32`
+/// dictionary size.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, FromBytes, Immutable, KnownLayout)]
+#[repr(C)]
+pub struct LzmaStreamHeader {
+    props: u8,
+    dict_size: U32<LE>,
+}
 
 impl LzmaStreamHeader {
-    /// Parses the 5-byte raw LZMA1 properties header used by Inno Setup's LZMA1
-    /// streams (same layout as the `.lzma` format): a single properties byte
-    /// encoding lc/lp/pb, followed by a little-endian `u32` dictionary size.
-    pub fn read<R>(src: &mut R) -> Result<(u8, u32)>
-    where
-        R: Read,
-    {
-        let mut properties = [0; 5];
-        src.read_exact(&mut properties)?;
-        let props = properties[0];
-        let dict_size = u32::from_le_bytes([
-            properties[1],
-            properties[2],
-            properties[3],
-            properties[4],
-        ]);
-        Ok((props, dict_size))
+    /// Returns the LZMA properties byte.
+    #[must_use]
+    #[inline]
+    pub const fn props(self) -> u8 {
+        self.props
+    }
+
+    /// Returns the LZMA dictionary size.
+    #[must_use]
+    #[inline]
+    pub const fn dictionary_size(self) -> u32 {
+        self.dict_size.get()
     }
 }

--- a/core/src/read/decoder.rs
+++ b/core/src/read/decoder.rs
@@ -1,12 +1,12 @@
 use std::io;
 
 use flate2::read::ZlibDecoder;
-use liblzma::read::XzDecoder;
+use lzma_rust2::LzmaReader;
 
 pub enum Decoder<R: io::Read> {
     Stored(R),
     Zlib(ZlibDecoder<R>),
-    LZMA1(XzDecoder<R>),
+    LZMA1(LzmaReader<R>),
 }
 
 impl<R: io::Read> Decoder<R> {
@@ -46,7 +46,7 @@ impl<R: io::Read> Decoder<R> {
         match self {
             Self::Stored(reader) => reader,
             Self::Zlib(reader) => reader.get_ref(),
-            Self::LZMA1(reader) => reader.get_ref(),
+            Self::LZMA1(reader) => reader.inner(),
         }
     }
 
@@ -58,7 +58,7 @@ impl<R: io::Read> Decoder<R> {
         match self {
             Self::Stored(reader) => reader,
             Self::Zlib(reader) => reader.get_mut(),
-            Self::LZMA1(reader) => reader.get_mut(),
+            Self::LZMA1(reader) => reader.inner_mut(),
         }
     }
 

--- a/core/src/read/decoder.rs
+++ b/core/src/read/decoder.rs
@@ -3,13 +3,32 @@ use std::io;
 use flate2::read::ZlibDecoder;
 use lzma_rust2::LzmaReader;
 
+use crate::LzmaStreamHeader;
+
 pub enum Decoder<R: io::Read> {
     Stored(R),
     Zlib(ZlibDecoder<R>),
-    LZMA1(LzmaReader<R>),
+    LZMA1(Box<LzmaReader<R>>),
 }
 
 impl<R: io::Read> Decoder<R> {
+    /// Creates a new LZMA1 decoder from a reader and an [`LzmaStreamHeader`].
+    pub fn new_lzma1(reader: R, header: LzmaStreamHeader) -> lzma_rust2::Result<Self> {
+        LzmaReader::new_with_props(
+            reader,
+            u64::MAX,
+            header.props(),
+            header.dictionary_size(),
+            None,
+        )
+        .map(|reader| Self::LZMA1(Box::new(reader)))
+    }
+
+    /// Creates a new Zlib decoder from a reader.
+    pub fn new_zlib(reader: R) -> Self {
+        Self::Zlib(ZlibDecoder::new(reader))
+    }
+
     /// Returns `true` if the underlying stream is compressed.
     #[must_use]
     #[inline]

--- a/core/src/read/stream.rs
+++ b/core/src/read/stream.rs
@@ -1,7 +1,5 @@
 use std::io::{Error, ErrorKind, Read, Result, Take};
 
-use flate2::read::ZlibDecoder;
-use lzma_rust2::LzmaReader;
 use zerocopy::LE;
 
 use crate::{
@@ -33,16 +31,9 @@ impl<R: Read> InnoStreamReader<R> {
             inner: match compression {
                 Compression::LZMA1(_) => {
                     let header = chunk_reader.read_t::<LzmaStreamHeader>()?;
-
-                    Decoder::LZMA1(LzmaReader::new_with_props(
-                        chunk_reader,
-                        u64::MAX,
-                        header.props(),
-                        header.dictionary_size(),
-                        None,
-                    )?)
+                    Decoder::new_lzma1(chunk_reader, header)?
                 }
-                Compression::Zlib(_) => Decoder::Zlib(ZlibDecoder::new(chunk_reader)),
+                Compression::Zlib(_) => Decoder::new_zlib(chunk_reader),
                 Compression::Stored(_) => Decoder::Stored(chunk_reader),
             },
             compression,

--- a/core/src/read/stream.rs
+++ b/core/src/read/stream.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind, Read, Result, Take};
 
 use flate2::read::ZlibDecoder;
-use liblzma::read::XzDecoder;
+use lzma_rust2::LzmaReader;
 use zerocopy::LE;
 
 use crate::{
@@ -16,6 +16,16 @@ use crate::{
     },
     version::InnoVersion,
 };
+
+/// Upper bound for the `dict_size` field in the 5-byte LZMA1 properties
+/// header.
+///
+/// The LZMA1 format allows dictionaries up to ~4 GiB, but real Inno Setup
+/// installers use small dictionaries (Inno's default is 8 MiB). 256 MiB is far
+/// above anything produced in practice, while still preventing a crafted
+/// installer from forcing `LzmaReader` into a multi-gigabyte allocation on
+/// construction.
+const MAX_LZMA1_DICT_SIZE: u32 = 256 * 1024 * 1024;
 
 pub struct InnoStreamReader<R: Read> {
     inner: Decoder<InnoBlockReader<Take<R>>>,
@@ -32,8 +42,20 @@ impl<R: Read> InnoStreamReader<R> {
         Ok(Self {
             inner: match compression {
                 Compression::LZMA1(_) => {
-                    let stream = LzmaStreamHeader::read(&mut chunk_reader)?;
-                    Decoder::LZMA1(XzDecoder::new_stream(chunk_reader, stream))
+                    let (props, dict_size) = LzmaStreamHeader::read(&mut chunk_reader)?;
+                    if dict_size > MAX_LZMA1_DICT_SIZE {
+                        return Err(Error::new(
+                            ErrorKind::InvalidData,
+                            format!("LZMA1 dictionary size too large: {dict_size} bytes"),
+                        ));
+                    }
+                    Decoder::LZMA1(LzmaReader::new_with_props(
+                        chunk_reader,
+                        u64::MAX,
+                        props,
+                        dict_size,
+                        None,
+                    )?)
                 }
                 Compression::Zlib(_) => Decoder::Zlib(ZlibDecoder::new(chunk_reader)),
                 Compression::Stored(_) => Decoder::Stored(chunk_reader),

--- a/core/src/read/stream.rs
+++ b/core/src/read/stream.rs
@@ -17,16 +17,6 @@ use crate::{
     version::InnoVersion,
 };
 
-/// Upper bound for the `dict_size` field in the 5-byte LZMA1 properties
-/// header.
-///
-/// The LZMA1 format allows dictionaries up to ~4 GiB, but real Inno Setup
-/// installers use small dictionaries (Inno's default is 8 MiB). 256 MiB is far
-/// above anything produced in practice, while still preventing a crafted
-/// installer from forcing `LzmaReader` into a multi-gigabyte allocation on
-/// construction.
-const MAX_LZMA1_DICT_SIZE: u32 = 256 * 1024 * 1024;
-
 pub struct InnoStreamReader<R: Read> {
     inner: Decoder<InnoBlockReader<Take<R>>>,
     compression: Compression,
@@ -42,18 +32,13 @@ impl<R: Read> InnoStreamReader<R> {
         Ok(Self {
             inner: match compression {
                 Compression::LZMA1(_) => {
-                    let (props, dict_size) = LzmaStreamHeader::read(&mut chunk_reader)?;
-                    if dict_size > MAX_LZMA1_DICT_SIZE {
-                        return Err(Error::new(
-                            ErrorKind::InvalidData,
-                            format!("LZMA1 dictionary size too large: {dict_size} bytes"),
-                        ));
-                    }
+                    let header = chunk_reader.read_t::<LzmaStreamHeader>()?;
+
                     Decoder::LZMA1(LzmaReader::new_with_props(
                         chunk_reader,
                         u64::MAX,
-                        props,
-                        dict_size,
+                        header.props(),
+                        header.dictionary_size(),
                         None,
                     )?)
                 }


### PR DESCRIPTION
Replace the `liblzma` dependency (which links to the C `liblzma`) with `lzma-rust2`, a pure-Rust LZMA/LZMA2 implementation.

This removes the need for a C toolchain and the
companion `lzma-static` feature for downstream consumers and avoids colision linking `-lzma` from xz/xz2 which is already used in many crate in the ecosystem.